### PR TITLE
Instead of new Buffer using Buffer.from  

### DIFF
--- a/lib/as.js
+++ b/lib/as.js
@@ -10,9 +10,9 @@ function asBuffer(body, options) {
   if (Buffer.isBuffer(body)) {
     ret = body;
   } else if (typeof body === 'object') {
-    ret = new Buffer(JSON.stringify(body), options.reqBodyEncoding);
+    ret = Buffer.from(JSON.stringify(body), options.reqBodyEncoding);
   } else if (typeof body === 'string') {
-    ret = new Buffer(body, options.reqBodyEncoding);
+    ret = Buffer.from(body, options.reqBodyEncoding);
   }
   return ret;
 }


### PR DESCRIPTION
As per https://nodejs.org/api/buffer.html#buffer_new_buffer_string_encoding new Buffer is deprecated changing code to use Buffer.from